### PR TITLE
Add pyproject.toml for build system configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a `[build-system]` section specifying the required build tools and backend for the project.